### PR TITLE
Quiet Vendor Logging with PSR Adapter

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4018,12 +4018,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:phoneburner/salt-lite.git",
-                "reference": "8dfe5e9c0b4f0d8ad15a814722b08564ad105805"
+                "reference": "d848c54a636187e04734e435edcd02a9190a9ea0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phoneburner/salt-lite/zipball/8dfe5e9c0b4f0d8ad15a814722b08564ad105805",
-                "reference": "8dfe5e9c0b4f0d8ad15a814722b08564ad105805",
+                "url": "https://api.github.com/repos/phoneburner/salt-lite/zipball/d848c54a636187e04734e435edcd02a9190a9ea0",
+                "reference": "d848c54a636187e04734e435edcd02a9190a9ea0",
                 "shasum": ""
             },
             "require": {
@@ -4074,11 +4074,11 @@
                 "phoneburner/composer-replacements": "dev-main",
                 "phoneburner/salt-lite-phpstan": "dev-main",
                 "php-parallel-lint/php-parallel-lint": "^1.4",
-                "phpunit/phpunit": "^12.1.2",
+                "phpunit/phpunit": "^12.1.4",
                 "psy/psysh": "^0.12.8",
-                "rector/rector": "^2.0.7",
+                "rector/rector": "^2.0.15",
                 "roave/security-advisories": "dev-latest",
-                "symfony/var-dumper": "^7.2.3"
+                "symfony/var-dumper": "^7.2.6"
             },
             "default-branch": true,
             "type": "library",
@@ -4156,7 +4156,7 @@
                 "source": "https://github.com/phoneburner/salt-lite/tree/main",
                 "issues": "https://github.com/phoneburner/salt-lite/issues"
             },
-            "time": "2025-05-07T00:28:40+00:00"
+            "time": "2025-05-12T21:11:35+00:00"
         },
         {
             "name": "psr/cache",

--- a/src/MessageBus/MessageBusServiceProvider.php
+++ b/src/MessageBus/MessageBusServiceProvider.php
@@ -25,6 +25,8 @@ use PhoneBurner\SaltLite\Framework\MessageBus\TransportFactory\DoctrineTransport
 use PhoneBurner\SaltLite\Framework\MessageBus\TransportFactory\InMemoryTransportFactory;
 use PhoneBurner\SaltLite\Framework\MessageBus\TransportFactory\RedisTransportFactory;
 use PhoneBurner\SaltLite\Framework\MessageBus\TransportFactory\SyncTransportFactory;
+use PhoneBurner\SaltLite\Logging\LogLevel;
+use PhoneBurner\SaltLite\Logging\PsrLoggerAdapter;
 use PhoneBurner\SaltLite\MessageBus\Handler\InvokableMessageHandler;
 use PhoneBurner\SaltLite\MessageBus\MessageBus;
 use PhoneBurner\SaltLite\Time\Clock\Clock;
@@ -197,7 +199,7 @@ final class MessageBusServiceProvider implements ServiceProvider
                 $app->get(RoutableMessageBus::class),
                 $app->get(ReceiverContainer::class),
                 $app->get(SymfonyEventDispatcherInterface::class),
-                $app->get(LoggerInterface::class),
+                new PsrLoggerAdapter($app->get(LoggerInterface::class), LogLevel::Debug),
                 $app->get(ReceiverContainer::class)->keys(),
                 new ResetServicesListener(
                     $app->get(LongRunningProcessServiceResetter::class),
@@ -264,7 +266,7 @@ final class MessageBusServiceProvider implements ServiceProvider
             StopWorkerOnRestartSignalListener::class,
             static fn(App $app): StopWorkerOnRestartSignalListener => new StopWorkerOnRestartSignalListener(
                 $app->get(CacheItemPoolInterface::class),
-                $app->get(LoggerInterface::class),
+                new PsrLoggerAdapter($app->get(LoggerInterface::class), LogLevel::Debug),
             ),
         );
 


### PR DESCRIPTION
Downgrade some routine log entries generated by the Symfony Message Bus that are hardcoded as `INFO` to `DEBUG` by wrapping the resolved PSR-3 logger implementation in the PSRLoggerAdapter with a log level override.
