### PR TITLE
Add Emitter Support for SSE

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4017,13 +4017,13 @@
             "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "git@github.com:phoneburner/salt-lite.git",
-                "reference": "d848c54a636187e04734e435edcd02a9190a9ea0"
+                "url": "https://github.com/phoneburner/salt-lite.git",
+                "reference": "c21a841e446ea4a9bd556580a9119973a9857b8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phoneburner/salt-lite/zipball/d848c54a636187e04734e435edcd02a9190a9ea0",
-                "reference": "d848c54a636187e04734e435edcd02a9190a9ea0",
+                "url": "https://api.github.com/repos/phoneburner/salt-lite/zipball/c21a841e446ea4a9bd556580a9119973a9857b8b",
+                "reference": "c21a841e446ea4a9bd556580a9119973a9857b8b",
                 "shasum": ""
             },
             "require": {
@@ -4156,7 +4156,7 @@
                 "source": "https://github.com/phoneburner/salt-lite/tree/main",
                 "issues": "https://github.com/phoneburner/salt-lite/issues"
             },
-            "time": "2025-05-12T21:11:35+00:00"
+            "time": "2025-05-22T16:50:54+00:00"
         },
         {
             "name": "psr/cache",

--- a/src/Http/Emitter/MappingEmitter.php
+++ b/src/Http/Emitter/MappingEmitter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhoneBurner\SaltLite\Framework\Http\Emitter;
+
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use Laminas\HttpHandlerRunner\Emitter\SapiStreamEmitter;
+use PhoneBurner\SaltLite\Http\Response\ServerSentEventsResponse;
+use PhoneBurner\SaltLite\Http\Response\StreamResponse;
+use Psr\Http\Message\ResponseInterface;
+
+class MappingEmitter implements EmitterInterface
+{
+    public const int DEFAULT_BUFFER_SIZE = 8192;
+
+    public function __construct(
+        private readonly int $buffer_size = self::DEFAULT_BUFFER_SIZE,
+    ) {
+    }
+
+    public function emit(ResponseInterface $response): bool
+    {
+        return (match (true) {
+            $response instanceof ServerSentEventsResponse => new UnbufferedSapiStreamEmitter(),
+            $response instanceof StreamResponse => new SapiStreamEmitter($this->buffer_size),
+            default => new SapiEmitter(),
+        })->emit($response);
+    }
+}

--- a/src/Http/Emitter/UnbufferedSapiStreamEmitter.php
+++ b/src/Http/Emitter/UnbufferedSapiStreamEmitter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhoneBurner\SaltLite\Framework\Http\Emitter;
+
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use Laminas\HttpHandlerRunner\Emitter\SapiEmitterTrait;
+use PhoneBurner\SaltLite\Http\Response\ServerSentEventsResponse;
+use PhoneBurner\SaltLite\Time\Ttl;
+use Psr\Http\Message\ResponseInterface;
+
+class UnbufferedSapiStreamEmitter implements EmitterInterface
+{
+    use SapiEmitterTrait;
+
+    public const int DEFAULT_BUFFER_SIZE = 8192;
+
+    public function emit(ResponseInterface $response): bool
+    {
+        // Reset the time limit so the runtime does not terminate early
+        if ($response instanceof ServerSentEventsResponse) {
+            \set_time_limit($response->ttl == Ttl::max() ? 0 : $response->ttl->seconds);
+        }
+
+        $this->assertNoPreviousOutput();
+        $this->emitHeaders($response);
+        $this->emitStatusLine($response);
+        \flush();
+
+        $body = $response->getBody();
+        while (! $body->eof()) {
+            echo $body->read(self::DEFAULT_BUFFER_SIZE);
+            \ob_flush();
+            \flush();
+        }
+
+        return true;
+    }
+}

--- a/src/Http/HttpServiceProvider.php
+++ b/src/Http/HttpServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhoneBurner\SaltLite\Framework\Http;
 
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
-use Laminas\HttpHandlerRunner\Emitter\SapiStreamEmitter;
 use PhoneBurner\SaltLite\App\App;
 use PhoneBurner\SaltLite\Attribute\Usage\Internal;
 use PhoneBurner\SaltLite\Container\DeferrableServiceProvider;
@@ -13,6 +12,7 @@ use PhoneBurner\SaltLite\Container\ServiceFactory\NewInstanceServiceFactory;
 use PhoneBurner\SaltLite\Cryptography\Natrium;
 use PhoneBurner\SaltLite\Framework\Http\Cookie\CookieEncrypter;
 use PhoneBurner\SaltLite\Framework\Http\Cookie\Middleware\ManageCookies;
+use PhoneBurner\SaltLite\Framework\Http\Emitter\MappingEmitter;
 use PhoneBurner\SaltLite\Framework\Http\Middleware\CatchExceptionalResponses;
 use PhoneBurner\SaltLite\Framework\Http\Middleware\TransformHttpExceptionResponses;
 use PhoneBurner\SaltLite\Framework\Http\RequestHandler\CspViolationReportRequestHandler;
@@ -130,7 +130,7 @@ final class HttpServiceProvider implements DeferrableServiceProvider
 
         $app->set(
             EmitterInterface::class,
-            static fn(App $app): EmitterInterface => new SapiStreamEmitter(),
+            static fn(App $app): EmitterInterface => new MappingEmitter(),
         );
 
         $app->set(


### PR DESCRIPTION
Replace `SapiStreamEmitter` with a new `MappingEmitter` for better response type handling. Introduced `MappingEmitter` and `UnbufferedSapiStreamEmitter` classes to support specific responses like `StreamResponse` and `ServerSentEventsResponse`. This enhances flexibility and optimizes response emission based on type.
